### PR TITLE
#7 Fix double free

### DIFF
--- a/src/XKbSwitch.cpp
+++ b/src/XKbSwitch.cpp
@@ -64,7 +64,7 @@ string print_layouts(const string_vector& sv)
   return oss.str();
 }
 
-void i3_watch(XKeyboard& xkb, const string_vector& syms) {
+void i3_watch(XKeyboard& xkb, string_vector& syms) {
   map<int, int> window_group_map;
   int previous_container_id = 0;
   int default_group = xkb.get_group();
@@ -101,6 +101,7 @@ void i3_watch(XKeyboard& xkb, const string_vector& syms) {
         xkb.set_group(new_group);
         previous_container_id = ev.container->id;
 
+        xkb.build_layout(syms);
         std::cout << "\tWindow layout: " << syms.at(new_group) << std::endl;
       }
     }

--- a/src/XKbSwitch.cpp
+++ b/src/XKbSwitch.cpp
@@ -64,7 +64,7 @@ string print_layouts(const string_vector& sv)
   return oss.str();
 }
 
-void i3_watch(XKeyboard xkb, const string_vector& syms) {
+void i3_watch(XKeyboard& xkb, const string_vector& syms) {
   map<int, int> window_group_map;
   int previous_container_id = 0;
   int default_group = xkb.get_group();

--- a/src/XKeyboard.cpp
+++ b/src/XKeyboard.cpp
@@ -119,6 +119,8 @@ void XKeyboard::build_layout_from(string_vector& out, const layout_variant_strin
   std::istringstream layout(lv.first);
   std::istringstream variant(lv.second);
 
+  out.clear();
+
   while(true) {
     string l,v;
 


### PR DESCRIPTION
Fixes #7 

`XKeyboard` is once passed by value, which effectively creates a copy of this object. Therefore, they reference the same X objects. However, the destructors for each of them is called, which try to free these X objects. The first destructor works, but the second crashes because of trying to free already free'd memory.

Potentially fixes #6 as well.

The code in this PR works as-is, but introduces a memory leak and results into wrong outputs because of an error in the original project (xkb-switch). All this is fixed with my other PR to the original repo https://github.com/grwlf/xkb-switch/pull/66.
Therefore, I'll mark this PR as a draft until the other PR is merged.